### PR TITLE
Fix outdated reservations showing up on cancel

### DIFF
--- a/main.py
+++ b/main.py
@@ -79,10 +79,34 @@ def set_booking(day, slot, data):
     save_db()
 
 def cleanup_old_bookings():
-    today = datetime.now().date()
-    to_delete = [day for day in bookingsDB if datetime.strptime(day, "%d/%m/%Y").date() < today]
-    for d in to_delete:
+    now = datetime.now()
+    today = now.date()
+
+    # Remove days completely in the past
+    past_days = [
+        day
+        for day in bookingsDB
+        if datetime.strptime(day, "%d/%m/%Y").date() < today
+    ]
+    for d in past_days:
         del bookingsDB[d]
+
+    # Remove expired slots from today
+    today_str = now.strftime("%d/%m/%Y")
+    if today_str in bookingsDB:
+        slots = list(bookingsDB[today_str].keys())
+        for slot in slots:
+            try:
+                end_str = slot.split("–")[1]
+                end_time = datetime.strptime(end_str, "%H:%M").time()
+            except Exception:
+                continue
+            end_dt = datetime.combine(today, end_time)
+            if end_dt <= now:
+                del bookingsDB[today_str][slot]
+        if not bookingsDB[today_str]:
+            del bookingsDB[today_str]
+
     save_db()
 
 # ---- Хендлеры ----
@@ -113,6 +137,7 @@ async def reservar(update: Update, context: ContextTypes.DEFAULT_TYPE):
 async def cancelar(update: Update, context: ContextTypes.DEFAULT_TYPE):
     chat_id = update.effective_chat.id
     username = update.message.from_user.username or update.message.from_user.first_name
+    cleanup_old_bookings()
     user_bookings = []
     for day, slots in bookingsDB.items():
         for slot, info in slots.items():


### PR DESCRIPTION
## Summary
- clean up expired bookings including same-day slots that already ended
- invoke cleanup before listing cancel options

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6872d7779ea0832cb9a419f7f427e7be